### PR TITLE
Use HTTPS URLs for Maven repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,15 +111,9 @@
         </repository>
 
         <repository>
-            <id>netbeans</id>
-            <name>NetBeans</name>
-            <url>http://bits.netbeans.org/maven2/</url>
-        </repository>
-
-        <repository>
     			<id>jzy3d-snapshots</id>
     			<name>Jzy3d Snapshots</name>
-    			<url>http://maven.jzy3d.org/snapshots/</url>
+    			<url>https://maven.jzy3d.org/snapshots/</url>
           <snapshots>
              <enabled>true</enabled>
           </snapshots>
@@ -127,7 +121,7 @@
     		<repository>
     			<id>jzy3d-releases</id>
     			<name>Jzy3d Releases</name>
-    			<url>http://maven.jzy3d.org/releases/</url>
+    			<url>https://maven.jzy3d.org/releases/</url>
           <snapshots>
              <enabled>false</enabled>
           </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.mvn.ftp>1.0-beta-6</version.mvn.ftp>
-
     </properties>
-
-
 
 
     <dependencies>
@@ -22,18 +19,16 @@
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
 
-		<dependency>
-		    <groupId>org.gephi</groupId>
-		    <artifactId>gephi-toolkit</artifactId>
-		    <version>0.9.1</version>
-		    <!-- <classifier>all</classifier>-->
-		</dependency>
-
-
+        <dependency>
+            <groupId>org.gephi</groupId>
+            <artifactId>gephi-toolkit</artifactId>
+            <version>0.9.1</version>
+            <!-- <classifier>all</classifier> -->
+        </dependency>
     </dependencies>
 
     <build>
-<!--        <testSourceDirectory>src/test/java</testSourceDirectory>-->
+        <!-- <testSourceDirectory>src/test/java</testSourceDirectory> -->
         <plugins>
             <!--<plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -71,12 +66,12 @@
         </plugins>
 
         <extensions>
-    			<extension>
-    				<groupId>org.apache.maven.wagon</groupId>
-    				<artifactId>wagon-ftp</artifactId>
-    				<version>${version.mvn.ftp}</version>
-    			</extension>
-    		</extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ftp</artifactId>
+                <version>${version.mvn.ftp}</version>
+            </extension>
+        </extensions>
     </build>
 
     <profiles>
@@ -91,53 +86,53 @@
         </profile>
     </profiles>
 
-       <repositories>
+    <repositories>
         <repository>
-           <id>oss-sonatype</id>
-           <name>oss-sonatype</name>
-           <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-           <snapshots>
-              <enabled>true</enabled>
-           </snapshots>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
 
         <repository>
-           <id>oss-sonatype-release</id>
-           <name>oss-sonatype-release</name>
-           <url>https://oss.sonatype.org/content/repositories/releases/</url>
-           <snapshots>
-              <enabled>false</enabled>
-           </snapshots>
+            <id>oss-sonatype-release</id>
+            <name>oss-sonatype-release</name>
+            <url>https://oss.sonatype.org/content/repositories/releases/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
 
         <repository>
-    			<id>jzy3d-snapshots</id>
-    			<name>Jzy3d Snapshots</name>
-    			<url>https://maven.jzy3d.org/snapshots/</url>
-          <snapshots>
-             <enabled>true</enabled>
-          </snapshots>
-    		</repository>
-    		<repository>
-    			<id>jzy3d-releases</id>
-    			<name>Jzy3d Releases</name>
-    			<url>https://maven.jzy3d.org/releases/</url>
-          <snapshots>
-             <enabled>false</enabled>
-          </snapshots>
-    		</repository>
-     </repositories>
+            <id>jzy3d-snapshots</id>
+            <name>Jzy3d Snapshots</name>
+            <url>https://maven.jzy3d.org/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>jzy3d-releases</id>
+            <name>Jzy3d Releases</name>
+            <url>https://maven.jzy3d.org/releases/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
-     <distributionManagement>
-   		<repository>
-   			<id>jzy3d-ftp</id>
-   			<name>Jzy3d Maven Folder</name>
-   			<url>ftp://ftp.cluster013.ovh.net/maven/releases</url>
-   		</repository>
-   		<snapshotRepository>
-   			<id>jzy3d-ftp</id>
-   			<name>Jzy3d Maven Folder SNAPSHOTS</name>
-   			<url>ftp://ftp.cluster013.ovh.net/maven/snapshots</url>
-   		</snapshotRepository>
-   	</distributionManagement>
+    <distributionManagement>
+        <repository>
+            <id>jzy3d-ftp</id>
+            <name>Jzy3d Maven Folder</name>
+            <url>ftp://ftp.cluster013.ovh.net/maven/releases</url>
+        </repository>
+        <snapshotRepository>
+            <id>jzy3d-ftp</id>
+            <name>Jzy3d Maven Folder SNAPSHOTS</name>
+            <url>ftp://ftp.cluster013.ovh.net/maven/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
Removes http://bits.netbeans.org/maven2 because that repository does not exist anymore; opening that URL shows "Repository decommissioned.".

Additionally formats the POM because its indentation was inconsistent.